### PR TITLE
Fixes an issue parsing and validating the DSN URL

### DIFF
--- a/Raven/RavenConfig.swift
+++ b/Raven/RavenConfig.swift
@@ -8,55 +8,57 @@
 import Foundation
 
 public class RavenConfig {
-    let serverUrl : NSURL!
-    let publicKey : String!
-    let secretKey : String!
-    let projectId : String!
+    let serverUrl: NSURL!
+    let publicKey: String!
+    let secretKey: String!
+    let projectId: String!
     
     public init? (DSN : String) {
-        let DSNURL = NSURL(string: DSN)
-      
-        var pathComponents = DSNURL!.pathComponents as! [String]
-      
-        pathComponents.removeAtIndex(0) // always remove the first slash
-        
-        projectId = pathComponents.last // project id is the last element of the path
-
-        pathComponents.removeLast() // remove the project id...
-       
-        var path = "/".join(pathComponents)  // ...and construct the path again
-        
-        // Add a slash to the end of the path if there is a path
-        if (path != "") {
-            path += "/"
-        }
-        
-        var scheme: String = DSNURL!.scheme ?? "http"
-        
-        var port = DSNURL!.port
-        if (port == nil) {
-            if (DSNURL!.scheme == "https") {
-                port = 443;
-            } else {
-                port = 80;
+        if let DSNURL = NSURL(string: DSN), host = DSNURL.host {
+            var pathComponents = DSNURL.pathComponents as! [String]
+            
+            pathComponents.removeAtIndex(0) // always remove the first slash
+            
+            if let projectId = pathComponents.last {
+                self.projectId = projectId
+                
+                pathComponents.removeLast() // remove the project id...
+                
+                var path = "/".join(pathComponents)  // ...and construct the path again
+                
+                // Add a slash to the end of the path if there is a path
+                if (path != "") {
+                    path += "/"
+                }
+                
+                var scheme: String = DSNURL.scheme ?? "http"
+                
+                var port = DSNURL.port
+                if (port == nil) {
+                    if (DSNURL.scheme == "https") {
+                        port = 443;
+                    } else {
+                        port = 80;
+                    }
+                }
+                
+                //Setup the URL
+                serverUrl = NSURL(string: "\(scheme)://\(host):\(port!)\(path)/api/\(projectId)/store/")
+                
+                //Set the public and secret keys if the exist
+                publicKey = DSNURL.user ?? ""
+                secretKey = DSNURL.password ?? ""
+                
+                return
             }
         }
-      
-        serverUrl = NSURL(string:"\(scheme)://\(DSNURL!.host!):\(port!)\(path)/api/\(projectId)/store/")
-        publicKey = DSNURL!.user
-        secretKey = DSNURL!.password
-      
-      
-      if DSNURL?.host == nil{
+        
+        //The URL couldn't be parsed, so initialize to blank values and return nil
+        serverUrl = NSURL()
+        publicKey = ""
+        secretKey = ""
+        projectId = ""
+        
         return nil
-      }
-      if (pathComponents.count == 0)
-      {
-        println("Missing path")
-        return nil
-      }
-      if projectId == nil{
-        return nil
-      }
     }
 }


### PR DESCRIPTION
This fixes an issue I was having with the config init not validating my DSN URL even though I copied it directly from sentry.
While I was at it, I also removed all forced unwrapped optionals to adopt more type safety to prevent possible crashes while initializing the RavenConfig.

Github looks like I changed everything, but it's mostly just wrapped in several `if let` blocks
