### PR TITLE
Uncaught exception handler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Tommy Mikalsen - https://github.com/timorzadir
 
 Contributors
 Sean Cheng - https://github.com/remaerd
+Erik Sargent - https://github.com/eriksargent

--- a/README.md
+++ b/README.md
@@ -67,19 +67,12 @@ RavenClient.sharedClient?.captureError(error!)
 RavenClient.sharedClient?.captureError(error!, method: __FUNCTION__, file: __FILE__, line: __LINE__)
 ```
 
-### Handling exceptions
+## Handling exceptions
 
 If you want a global exception handler, you will need to add this to your [bridging header](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html): 
+
 ```objective-c
 #import "UncaughtExceptionHandler.h"
-```
-and in `UncaughtExceptionHandler.m` replace the 
-```objective-c
-#import "Raven-Swift.h"
-```
-with
-```objective-c
-#import "YourProductModuleName-Swift.h"
 ```
 
 Then you can set up a global exception handler:

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -13,7 +13,7 @@ import Foundation
 
 let userDefaultsKey = "nl.mixedCase.RavenClient.Exceptions"
 let sentryProtocol = "4"
-let sentryClient = "raven-swift/0.1.0"
+let sentryClient = "raven-swift/0.2.0"
 
 public enum RavenLogLevel: String {
     case Debug = "debug"
@@ -26,6 +26,7 @@ public enum RavenLogLevel: String {
 private var _RavenClientSharedInstance : RavenClient?
 
 public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDataDelegate  {
+    //MARK: - Properties
     public var extra: [String: AnyObject]
     public var tags: [String: String]
     public var user: [String: String]?
@@ -40,12 +41,27 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         return dateFormatter
     }
     
+    
+    //MARK: - Init
+    
+    
+    /**
+    Get the shared RavenClient instance
+    */
     public class var sharedClient: RavenClient? {
         return _RavenClientSharedInstance
     }
+    
    
-    public init(config: RavenConfig, extra: [String : AnyObject], tags: [String: String], logger: RavenLogLevel?)
-    {
+    /**
+    Initialize the RavenClient
+    
+    :param: config  RavenConfig object
+    :param: extra  extra data that will be sent with logs
+    :param: tags  extra tags that will be added to logs
+    :param: logger  log level
+    */
+    public init(config: RavenConfig, extra: [String : AnyObject], tags: [String: String], logger: RavenLogLevel?) {
         self.config = config
         self.extra = extra
         self.tags = tags
@@ -55,66 +71,133 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         setDefaultTags()
     }
     
-    public convenience init(config: RavenConfig, extra: [String: AnyObject], tags: [String: String])
-    {
+    
+    /**
+    Initialize the RavenClient
+    
+    :param: config  RavenConfig object
+    :param: extra  extra data that will be sent with logs
+    :param: tags  extra tags that will be added to logs
+    */
+    public convenience init(config: RavenConfig, extra: [String: AnyObject], tags: [String: String]) {
         self.init(config: config, extra: extra, tags: tags, logger: nil)
-        
     }
     
-    public convenience init(config: RavenConfig, extra: [String: AnyObject])
-    {
+    
+    /**
+    Initialize the RavenClient
+    
+    :param: config  RavenConfig object
+    :param: extra  extra data that will be sent with logs
+    */
+    public convenience init(config: RavenConfig, extra: [String: AnyObject]) {
         self.init(config: config, extra: extra, tags: [:], logger: nil)
-        
     }
     
-    public convenience init(config: RavenConfig)
-    {
+    
+    /**
+    Initialize the RavenClient
+    
+    :param: config  RavenConfig object
+    */
+    public convenience init(config: RavenConfig) {
         self.init(config: config, extra: [:], tags: [:], logger: nil)
     }
 
-    public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String], logger: RavenLogLevel?) -> RavenClient?
-    {
-        let config = RavenConfig(DSN: DSN)
-        if (config == nil)
-        {
+    
+    /**
+    Initialize a RavenClient from the DSN string
+    
+    :param: extra  extra data that will be sent with logs
+    :param: tags  extra tags that will be added to logs
+    :param: logger  log level
+    
+    :returns: The RavenClient instance
+    */
+    public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String], logger: RavenLogLevel?) -> RavenClient? {
+        if let config = RavenConfig(DSN: DSN) {
+            let client = RavenClient(config: config, extra: extra, tags: tags, logger: logger)
+            
+            if (_RavenClientSharedInstance == nil) {
+                _RavenClientSharedInstance = client
+            }
+            
+            return client
+        }
+        else {
             println("Invalid DSN: \(DSN)!")
             return nil
         }
-        
-        let client = RavenClient(config: config!, extra: extra, tags: tags, logger: logger)
-        
-        if (_RavenClientSharedInstance == nil) {
-            _RavenClientSharedInstance = client
-        }
-        
-        return client
     }
     
-    public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String]) -> RavenClient?
-    {
+    
+    /**
+    Initialize a RavenClient from the DSN string
+    
+    :param: extra  extra data that will be sent with logs
+    :param: tags  extra tags that will be added to logs
+    
+    :returns: The RavenClient instance
+    */
+    public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String]) -> RavenClient? {
         return RavenClient.clientWithDSN(DSN, extra: extra, tags: tags, logger: nil)
     }
     
-    public class func clientWithDSN(DSN: String, extra: [String: AnyObject]) -> RavenClient?
-    {
+    
+    /**
+    Initialize a RavenClient from the DSN string
+    
+    :param: extra  extra data that will be sent with logs
+    
+    :returns: The RavenClient instance
+    */
+    public class func clientWithDSN(DSN: String, extra: [String: AnyObject]) -> RavenClient? {
         return RavenClient.clientWithDSN(DSN, extra: extra, tags: [:])
     }
     
-    public class func clientWithDSN(DSN: String) -> RavenClient?
-    {
+    
+    /**
+    Initialize a RavenClient from the DSN string
+    
+    :returns: The RavenClient instance
+    */
+    public class func clientWithDSN(DSN: String) -> RavenClient? {
         return RavenClient.clientWithDSN(DSN, extra: [:])
     }
 
-    public func captureMessage(message : String)
-    {
+    
+    //MARK: - Messages
+    
+    
+    /**
+    Capture a message
+    
+    :param: message  The message to be logged
+    */
+    public func captureMessage(message : String) {
         self.captureMessage(message, level: .Info)
     }
     
-    public func captureMessage(message: String, level: RavenLogLevel, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__){
     
+    /**
+    Capture a message
+    
+    :param: message  The message to be logged
+    :param: level  log level
+    */
+    public func captureMessage(message: String, level: RavenLogLevel, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__){
         self.captureMessage(message, level: level, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
     
+    
+    /**
+    Capture a message
+    
+    :param: message  The message to be logged
+    :param: level  log level
+    :param: additionalExtra  Additional data that will be sent with the log
+    :param: additionalTags  Additional tags that will be sent with the log
+    */
     public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: String], method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__) {
         var stacktrace : [AnyObject] = []
         var culprit : String = ""
@@ -131,18 +214,50 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         self.sendDictionary(data)
     }
     
-    public func captureError(error : NSError, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__){
+    
+    //MARK: - Error
+    
+    /** 
+    Capture an error
+    
+    :param: error  The error to capture
+    */
+    public func captureError(error : NSError, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
         RavenClient.sharedClient?.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
     
-    public func captureException(exception :NSException) {
+    
+    //MARK: - Exception
+    
+    
+    /**
+    Capture an exception. Automatically sends to the server
+    
+    :param: exception  The exception to be captured.
+    */
+    public func captureException(exception: NSException) {
         self.captureException(exception, sendNow:true)
     }
     
+    
+    /**
+    Capture an uncaught exception. Does not automatically send to the server
+    
+    :param: exception  The exception to be captured.
+    */
     public func captureUncaughtException(exception: NSException) {
         self.captureException(exception, sendNow: false)
     }
     
+    
+    /**
+    Capture an exception
+    
+    :param: exception  The exception to be captured.
+    :param: additionalExtra  Additional data that will be sent with the log
+    :param: additionalTags  Additional tags that will be sent with the log
+    :param: sendNow  Control whether the exception is sent to the server now, or when the app is next opened
+    */
     public func captureException(exception:NSException, additionalExtra:[String: AnyObject], additionalTags: [String: String], sendNow:Bool) {
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason!]
@@ -151,17 +266,15 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         
         var stacktrace = [[String:String]]()
         
-        if (!callStack.isEmpty)
-        {
-            for call in callStack
-            {
+        if (!callStack.isEmpty) {
+            for call in callStack {
                 stacktrace.append(["function": call as! String])
             }
         }
         
         let data = self.prepareDictionaryForMessage(message, level: .Fatal, additionalExtra: additionalExtra, additionalTags: additionalTags, culprit: nil, stacktrace: stacktrace, exception: exceptionDict)
-        if let JSON = self.encodeJSON(data)
-        {
+        
+        if let JSON = self.encodeJSON(data) {
             if (!sendNow) {
                 // We can't send this exception to Sentry now, e.g. because the app is killed before the
                 // connection can be made. So, save it into NSUserDefaults.
@@ -179,13 +292,18 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
                 self.sendJSON(JSON)
             }
         }
-        
     }
     
+    
+    /**
+    Capture an exception
+    
+    :param: exception  The exception to be captured.
+    :param: sendNow  Control whether the exception is sent to the server now, or when the app is next opened
+    */
     public func captureException(exception: NSException, method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__, sendNow:Bool = false) {
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason ?? ""]
-        
         
         var stacktrace = [[String:AnyObject]]()
         
@@ -203,8 +321,7 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         
         let data = self.prepareDictionaryForMessage(message, level: .Fatal, additionalExtra: [:], additionalTags: [:], culprit: nil, stacktrace: stacktrace, exception: exceptionDict)
         
-        if let JSON = self.encodeJSON(data)
-        {
+        if let JSON = self.encodeJSON(data) {
             if (!sendNow) {
                 // We can't send this exception to Sentry now, e.g. because the app is killed before the
                 // connection can be made. So, save the JSON payload into NSUserDefaults.
@@ -223,6 +340,10 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         }
     }
 
+    
+    /**
+    Automatically capture any uncaught exceptions
+    */
     public func setupExceptionHandler() {
         UncaughtExceptionHandler.registerHandler(self)
         NSSetUncaughtExceptionHandler(exceptionHandlerPtr)
@@ -240,6 +361,8 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         }
     }
 
+    
+    //MARK: - NSURLConnection
     public func connection(connection: NSURLConnection, didFailWithError error: NSError) {
         let userInfo = error.userInfo as! [String: AnyObject]
         let errorKey: AnyObject? = userInfo[NSURLErrorFailingURLStringErrorKey]
@@ -255,7 +378,8 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     public func connectionDidFinishLoading(connection: NSURLConnection) {
         println("JSON sent to Sentry")
     }
-    
+
+    //MARK: - Internal methods
     internal func setDefaultTags() {
         if tags["Build version"] == nil {
             if let buildVersion: AnyObject = NSBundle.mainBundle().infoDictionary?["CFBundleShortVersionString"]
@@ -330,9 +454,7 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         return data
     }
     
-    private func sendJSON(JSON: NSData?)
-    {
-        
+    private func sendJSON(JSON: NSData?) {
         let header = "Sentry sentry_version=\(sentryProtocol), sentry_client=\(sentryClient), sentry_timestamp=\(NSDate.timeIntervalSinceReferenceDate()), sentry_key=\(self.config.publicKey), sentry_secret=\(self.config.secretKey)"
         
         #if DEBUG

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -136,8 +136,11 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         self.captureException(exception, sendNow:true)
     }
     
+    public func captureUncaughtException(exception: NSException) {
+        self.captureException(exception, sendNow: false)
+    }
+    
     public func captureException(exception:NSException, additionalExtra:[String: AnyObject], additionalTags: [String: String], sendNow:Bool) {
-        
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason!]
         
@@ -218,7 +221,7 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     }
 
     public func setupExceptionHandler() {
-    
+        UncaughtExceptionHandler.registerHandler(self)
         NSSetUncaughtExceptionHandler(exceptionHandlerPtr)
         
         // Process saved crash reports

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -30,7 +30,7 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     public var extra: [String: AnyObject]
     public var tags: [String: String]
     public var user: [String: String]?
-    public let logger: RavenLogLevel?
+    public let logger: String?
     
     internal let config: RavenConfig
     
@@ -59,9 +59,9 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     :param: config  RavenConfig object
     :param: extra  extra data that will be sent with logs
     :param: tags  extra tags that will be added to logs
-    :param: logger  log level
+    :param: logger  Name of the logger
     */
-    public init(config: RavenConfig, extra: [String : AnyObject], tags: [String: String], logger: RavenLogLevel?) {
+    public init(config: RavenConfig, extra: [String : AnyObject], tags: [String: String], logger: String?) {
         self.config = config
         self.extra = extra
         self.tags = tags
@@ -110,11 +110,11 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     
     :param: extra  extra data that will be sent with logs
     :param: tags  extra tags that will be added to logs
-    :param: logger  log level
+    :param: logger  Name of the logger
     
     :returns: The RavenClient instance
     */
-    public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String], logger: RavenLogLevel?) -> RavenClient? {
+    public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String], logger: String?) -> RavenClient? {
         if let config = RavenConfig(DSN: DSN) {
             let client = RavenClient(config: config, extra: extra, tags: tags, logger: logger)
             
@@ -439,7 +439,7 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
             "platform"  : "swift",
             "extra"     : extra,
             "tags"      : tags,
-            "logger"    : self.logger?.rawValue ?? "",
+            "logger"    : self.logger ?? "",
             "message"   : message,
             "culprit"   : culprit ?? "",
             "stacktrace": stacktraceDict,

--- a/Raven/UncaughtExceptionHandler.h
+++ b/Raven/UncaughtExceptionHandler.h
@@ -9,7 +9,10 @@
 
 void exceptionHandler(NSException *exception);
 extern NSUncaughtExceptionHandler *exceptionHandlerPtr;
+id ravenClient;
 
-@interface UncaughtExceptionHandler : NSObject 
+@interface UncaughtExceptionHandler : NSObject
+
++ (void)registerHandler: (id)raven;
 
 @end

--- a/Raven/UncaughtExceptionHandler.m
+++ b/Raven/UncaughtExceptionHandler.m
@@ -7,16 +7,20 @@
 
 #import "UncaughtExceptionHandler.h"
 
-//NOTE: Change this to YourProductModuleName-Swift.h
-//Ref: https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html
-#import "Raven/Raven-Swift.h"
 
 @implementation UncaughtExceptionHandler
 
 void exceptionHandler(NSException *exception) {
-    [[RavenClient sharedClient] captureException:exception];
+    SEL captureException = NSSelectorFromString(@"captureUncaughtException:");
+    if ([ravenClient respondsToSelector:captureException]) {
+        ((void (*)(id, SEL, NSException*))[ravenClient methodForSelector:captureException])(ravenClient, captureException, exception);
+    }
 }
 
 NSUncaughtExceptionHandler *exceptionHandlerPtr = &exceptionHandler;
+
++ (void)registerHandler: (id)raven {
+    ravenClient = raven;
+}
 
 @end


### PR DESCRIPTION
Makes the `UncaughtExceptionHandler` easier to use by making it work without requiring a user to import their project into Objective-C which also avoids issues if the project doesn't directly work with the conversion to Objective-C, and makes it work out of the box by only adding the `.h` file to the bridging header

Also makes the `RavenLogLevel` enum more swifty, and changes it to pass around objects of `RavenLogLevel` (e.g. Debug, or Fatal) rather than strings to improve safety

Cleaned up and standardized the syntax a little, then added documentation and help text to all public facing functions

Removed the now unnecessary exception handler documentation from the README
