### PR TITLE
Capture message line file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Swift client for [Sentry](https://www.getsentry.com/welcome/).
 
 ## Installation
 
-The easiest way is to use [CocoaPods](http://cocoapods.org) (NOTE: currently in beta). It takes care of all required frameworks and third party dependencies:
+The easiest way is to use [CocoaPods](http://cocoapods.org). It takes care of all of the setup, required frameworks and third party dependencies:
 
 Steps
 
-1. Install Cocoapods beta: ```ruby gem install cocoapods -pre```
-2. Add raven swift to podfile: ```ruby pod 'raven-swift', :git => 'https://github.com/getsentry/raven-swift.git', :tag => '0.1.0'```
-3. Install pods: ```ruby pod install```
+1. [Install Cocoapods](http://cocoapods.org)
+2. Add raven swift to podfile: ```pod 'RavenSwift'```
+3. Install: ```pod install```
 
 **Alternatively**, you can install manually.
 
@@ -28,6 +28,8 @@ Alternatively you can add this code as a Git submodule:
 
 
 ## How to get started
+
+*Note: If you are using cocoapods, import ```RavenSwift``` any where the raven client is used*
 
 While you are free to initialize as many instances of `RavenClient` as is appropriate for your application, there is a shared singleton instance that is globally available. This singleton instance is often configured in your app delegate's `application:didFinishLaunchingWithOptions:` method:
 
@@ -69,7 +71,7 @@ RavenClient.sharedClient?.captureError(error!, method: __FUNCTION__, file: __FIL
 
 ## Handling exceptions
 
-If you want a global exception handler, you will need to add this to your [bridging header](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html): 
+If you want a global exception handler, you will need to add this to your [bridging header](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html). This step is only required if it is manually installed. Cocoapods will handle this for you: 
 
 ```objective-c
 #import "UncaughtExceptionHandler.h"

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -174,8 +174,8 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     
     :param: message  The message to be logged
     */
-    public func captureMessage(message : String) {
-        self.captureMessage(message, level: .Info)
+    public func captureMessage(message : String, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__) {
+        self.captureMessage(message, level: .Info, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
     
     

--- a/RavenSwift.podspec
+++ b/RavenSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RavenSwift"
-  s.version      = "0.2.0"
+  s.version      = "0.2.1"
   s.summary      = "swift client for sentry"
   s.homepage     = "https://github.com/getsentry/raven-swift"
   s.license      = "mit"

--- a/RavenSwift.podspec
+++ b/RavenSwift.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "RavenSwift"
+  s.version      = "0.2.0"
+  s.summary      = "swift client for sentry"
+  s.homepage     = "https://github.com/getsentry/raven-swift"
+  s.license      = "mit"
+  s.authors      = "Tommy Mikalsen", "Erik Sargent", "Sean Cheng"
+  s.source       = { :git => "https://github.com/getsentry/raven-swift.git", :tag => s.version.to_s }
+
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.9"
+
+  s.source_files = "Raven/**/*.{h,m,swift}"
+  s.ios.exclude_files = "Raven/Raven-OSX.h"
+  s.osx.exclude_files = "Raven/Raven-iOS.h"
+end


### PR DESCRIPTION
Fixing the default capture message function to properly record the function, file and line number

If you could add the 0.2.1 tag and push to Cocoapods trunk that would be awesome.
