### PR TITLE
Brings back support for non-string values in tags and user dictionaries

### DIFF
--- a/Raven-SwiftTests/RavenClientTests.swift
+++ b/Raven-SwiftTests/RavenClientTests.swift
@@ -12,7 +12,7 @@ let testDSN = "http://public:secret@example.com/foo"
 class MockRavenClient : RavenClient {
     var lastEvent: [String: AnyObject] = [:]
     var numEvents = 0
-    
+
     override func sendDictionary(dict: [String : AnyObject]) {
         lastEvent = dict
         numEvents++
@@ -21,55 +21,55 @@ class MockRavenClient : RavenClient {
 
 
 class RavenClientTests: XCTestCase {
-    
+
     var client: MockRavenClient?
     var config = RavenConfig(DSN: testDSN)
-    
+
     override func setUp() {
         client = MockRavenClient(config: config!, extra: [:], tags: [:], logger: nil)
     }
-    
-    
+
+
     func testGenerateUUID() {
         let uuid = client!.generateUUID()
         XCTAssert(uuid.characters.count == 32 , "Invalid value for UUID returned: \(uuid)")
     }
-    
+
     func testCaptureMessageWithOnlyMessage() {
         if let client = client {
-            
+
             let testMessage = "An example message"
             client.captureMessage(testMessage)
             let lastEvent = client.lastEvent
-            
+
             XCTAssertNotNil(lastEvent["event_id"], "Missing event_id")
             XCTAssertNotNil(lastEvent["message"], "Missing message")
             XCTAssertNotNil(lastEvent["project"], "Missing project")
             XCTAssertNotNil(lastEvent["level"], "Missing level")
             XCTAssertNotNil(lastEvent["timestamp"], "Missing timestamp")
             XCTAssertNotNil(lastEvent["platform"], "Missing platform")
-            
+
             if let message = lastEvent["message"] as? String {
                 XCTAssertEqual(message, testMessage, "Invalid value for message: \(message)")
             }
             else {
                 XCTFail("The message was not a string")
             }
-            
+
             if let project = lastEvent["project"] as? String {
                 XCTAssertEqual(project, client.config.projectId!, "Invalid value for project: \(project)")
             }
             else {
                 XCTFail("The project was not a string")
             }
-            
+
             if let level = lastEvent["level"] as? String {
                 XCTAssertEqual(level, "info", "Invalid value for level: \(level) ")
             }
             else {
                 XCTFail("The level was not a string")
             }
-            
+
             if let platform = lastEvent["platform"] as? String {
                 XCTAssertEqual(platform, "swift", "Invalid value for platform: \(platform)")
             }
@@ -81,44 +81,44 @@ class RavenClientTests: XCTestCase {
             XCTFail("The client was nil")
         }
     }
-    
+
     func testCaptureMessageWithMessageAndLevel() {
         if let client = client {
-            
+
             let testMessage = "An example message"
             let testLevel = RavenLogLevel.Warning
             client.captureMessage(testMessage, level: testLevel)
             let lastEvent = self.client!.lastEvent
-            
+
             XCTAssertNotNil(lastEvent["event_id"], "Missing event_id")
             XCTAssertNotNil(lastEvent["message"], "Missing message")
             XCTAssertNotNil(lastEvent["project"], "Missing project")
             XCTAssertNotNil(lastEvent["level"], "Missing level")
             XCTAssertNotNil(lastEvent["timestamp"], "Missing timestamp")
             XCTAssertNotNil(lastEvent["platform"], "Missing platform")
-            
-            
+
+
             if let message = lastEvent["message"] as? String {
                 XCTAssertEqual(message, testMessage, "Invalid value for message: \(message)")
             }
             else {
                 XCTFail("Message was not a string")
             }
-            
+
             if let project = lastEvent["project"] as? String {
                 XCTAssertEqual(project, client.config.projectId!, "Invalid value for project: \(project)")
             }
             else {
                 XCTFail("Project was not a string")
             }
-            
+
             if let level = lastEvent["level"] as? String {
                 XCTAssertEqual(level, testLevel.rawValue, "Invalid value for level: \(level)")
             }
             else {
                 XCTFail("Warning was not a string")
             }
-            
+
             if let platform = lastEvent["platform"] as? String {
                 XCTAssertEqual(platform, "swift", "Invalid value for platform: \(platform)")
             }
@@ -130,8 +130,8 @@ class RavenClientTests: XCTestCase {
             XCTFail("The client was nil")
         }
     }
-    
-    
+
+
     func testCaptureMessageWithMessageAndLevelAndMethodAndFileAndLine() {
         if let client = client {
             let testMessage = "An example message"
@@ -139,10 +139,10 @@ class RavenClientTests: XCTestCase {
             let testMethod = "method name"
             let testFile = "filename"
             let testLine = 34
-            
+
             client.captureMessage(testMessage, level: testLevel, method: testMethod, file: testFile, line: testLine)
             let lastEvent = self.client!.lastEvent
-            
+
             XCTAssertNotNil(lastEvent["event_id"], "Missing event_id")
             XCTAssertNotNil(lastEvent["message"], "Missing message")
             XCTAssertNotNil(lastEvent["project"], "Missing project")
@@ -150,28 +150,28 @@ class RavenClientTests: XCTestCase {
             XCTAssertNotNil(lastEvent["timestamp"], "Missing timestamp")
             XCTAssertNotNil(lastEvent["platform"], "Missing platform")
             XCTAssertNotNil(lastEvent["stacktrace"], "Missing stacktrace")
-            
+
             if let message = lastEvent["message"] as? String {
                 XCTAssertEqual(message, testMessage, "Invalid value for message: \(message)")
             }
             else {
                 XCTFail("Message was not a string")
             }
-            
+
             if let project = lastEvent["project"] as? String {
                 XCTAssertEqual(project, client.config.projectId!, "Invalid value for project: \(project)")
             }
             else {
                 XCTFail("Project was not a string")
             }
-            
+
             if let level = lastEvent["level"] as? String {
                 XCTAssertEqual(level, testLevel.rawValue, "Invalid value for level: \(level)")
             }
             else {
                 XCTFail("Warning was not a string")
             }
-            
+
             if let platform = lastEvent["platform"] as? String {
                 XCTAssertEqual(platform, "swift", "Invalid value for platform: \(platform)")
             }
@@ -183,15 +183,15 @@ class RavenClientTests: XCTestCase {
             XCTFail("The client was nil")
         }
     }
-    
+
     func testCaptureMessageWithMessageAndLevelAndExtraAndTags() {
         if let client = client {
             let testMessage = "An example message"
             let testLevel = RavenLogLevel.Warning
-            
-            client.captureMessage(testMessage, level: testLevel, additionalExtra:["key" : "extra value"], additionalTags:["key" : "tag value"])
+
+            client.captureMessage(testMessage, level: testLevel, additionalExtra:["key" : "extra value"], additionalTags:["key" : "tag value", "bool": true, "number": 42])
             let lastEvent = self.client!.lastEvent
-            
+
             XCTAssertNotNil(lastEvent["event_id"], "Missing event_id")
             XCTAssertNotNil(lastEvent["message"], "Missing message")
             XCTAssertNotNil(lastEvent["project"], "Missing project")
@@ -200,28 +200,28 @@ class RavenClientTests: XCTestCase {
             XCTAssertNotNil(lastEvent["platform"], "Missing platform")
             XCTAssertNotNil(lastEvent["extra"], "Missing extra")
             XCTAssertNotNil(lastEvent["tags"], "Missing tags")
-            
+
             if let message = lastEvent["message"] as? String {
                 XCTAssertEqual(message, testMessage, "Invalid value for message: \(message)")
             }
             else {
                 XCTFail("Message was not a string")
             }
-            
+
             if let project = lastEvent["project"] as? String {
                 XCTAssertEqual(project, client.config.projectId!, "Invalid value for project: \(project)")
             }
             else {
                 XCTFail("Project was not a string")
             }
-            
+
             if let level = lastEvent["level"] as? String {
                 XCTAssertEqual(level, testLevel.rawValue, "Invalid value for level: \(level)")
             }
             else {
                 XCTFail("Warning was not a string")
             }
-            
+
             if let platform = lastEvent["platform"] as? String {
                 XCTAssertEqual(platform, "swift", "Invalid value for platform: \(platform)")
             }
@@ -233,25 +233,32 @@ class RavenClientTests: XCTestCase {
             XCTFail("The client was nil")
         }
     }
-    
+
     func testClientWithExtraAndTags() {
         let firstKey = "key"
         let secondKey = "key2"
         let extraValue = "extraValue"
         let tagValue = "tagValue"
-        
+
+        let tagsIntegerKey = "number"
+        let tagsIntegerValue = 42
+
+        let tagsBoolKey = "bool"
+        let tagsBoolValue = false
+
         let testMessage = "An example message"
         let testLevel = RavenLogLevel.Warning
-        
+
         let clientWithExtraAndTags = MockRavenClient(config: config!, extra: [firstKey: extraValue], tags: [firstKey: tagValue], logger: nil)
-        
-        clientWithExtraAndTags.captureMessage(testMessage, level: testLevel, additionalExtra: [secondKey: extraValue], additionalTags:[secondKey: tagValue])
-        
+
+        let additionalTags: [String: AnyObject] = [secondKey: tagValue, tagsIntegerKey: tagsIntegerValue, tagsBoolKey: tagsBoolValue]
+        clientWithExtraAndTags.captureMessage(testMessage, level: testLevel, additionalExtra: [secondKey: extraValue], additionalTags: additionalTags)
+
         let lastEvent = clientWithExtraAndTags.lastEvent
-        
+
         XCTAssertNotNil(lastEvent["extra"], "Missing extra")
         XCTAssertNotNil(lastEvent["tags"], "Missing tags")
-        
+
         if let extra = lastEvent["extra"] as? [String: AnyObject] {
             if let extraValueForKey = extra[firstKey] as? String {
                 XCTAssertEqual(extraValueForKey, extraValue, "Missing extra data")
@@ -259,7 +266,7 @@ class RavenClientTests: XCTestCase {
             else {
                 XCTFail("First extra data could not be converted to a string")
             }
-            
+
             if let extraValueForKey2 = extra[secondKey] as? String {
                 XCTAssertEqual(extraValueForKey2, extraValue, "Missing extra data")
             }
@@ -270,7 +277,7 @@ class RavenClientTests: XCTestCase {
         else {
             XCTFail("Could not parse the extra information")
         }
-        
+
         if let tags = lastEvent["tags"] as? [String: AnyObject] {
             if let tagValueForKey = tags[firstKey] as? String {
                 XCTAssertEqual(tagValueForKey, tagValue, "Missing tags data")
@@ -278,14 +285,28 @@ class RavenClientTests: XCTestCase {
             else {
                 XCTFail("First tag data could not be converted to a string")
             }
-            
+
             if let tagValueForKey2 = tags[secondKey] as? String {
                 XCTAssertEqual(tagValueForKey2, tagValue, "Missing tags data")
             }
             else {
                 XCTFail("Second tag data could not be converted to a string")
             }
-            
+
+            if let tagsIntegerKeyValue = tags[tagsIntegerKey] as? Int {
+                XCTAssertEqual(tagsIntegerKeyValue, tagsIntegerValue, "Missin tags data")
+            }
+            else {
+                XCTFail("Tags number key value could not be converted to an Int")
+            }
+
+            if let tagsBoolKeyValue = tags[tagsBoolKey] as? Bool {
+                XCTAssertEqual(tagsBoolKeyValue, tagsBoolValue, "Missin tags data")
+            }
+            else {
+                XCTFail("Tags bool key value could not be converted to a Bool")
+            }
+
             XCTAssertNotNil(tags["OS version"], "Missing tags data (OS Version)")
             XCTAssertNotNil(tags["Device model"], "Missing tags data (Device Model)")
         }
@@ -293,26 +314,26 @@ class RavenClientTests: XCTestCase {
             XCTFail("Could not parse the tag information")
         }
     }
-    
+
     func testClientWithRewritingExtraAndTags() {
         let key = "key"
         let extraValue = "extraValue"
         let secondExtraValue = "AnotherExtraValue"
         let tagValue = "tagValue"
         let secondTagValue = "AnotherTagValue"
-        
+
         let testMessage = "An example message"
         let testLevel = RavenLogLevel.Warning
-        
+
         let clientWithExtraAndTags = MockRavenClient(config: config!, extra: [key: extraValue], tags: [key: tagValue], logger: nil)
-        
+
         clientWithExtraAndTags.captureMessage(testMessage, level: testLevel, additionalExtra: [key: secondExtraValue], additionalTags:[key: secondTagValue])
-        
+
         let lastEvent = clientWithExtraAndTags.lastEvent
-        
+
         XCTAssertNotNil(lastEvent["extra"], "Missing extra")
         XCTAssertNotNil(lastEvent["tags"], "Missing tags")
-        
+
         if let extra = lastEvent["extra"] as? [String: AnyObject] {
             if let extraValueForKey = extra[key] as? String {
                 XCTAssertEqual(extraValueForKey, secondExtraValue, "Incorrect extra data")
@@ -325,7 +346,7 @@ class RavenClientTests: XCTestCase {
         else {
             XCTFail("Could not parse the extra information")
         }
-        
+
         if let tags = lastEvent["tags"] as? [String: AnyObject] {
             if let tagValueForKey = tags[key] as? String {
                 XCTAssertEqual(tagValueForKey, secondTagValue, "Incorrect tags data")
@@ -334,7 +355,7 @@ class RavenClientTests: XCTestCase {
             else {
                 XCTFail("First tag data could not be converted to a string")
             }
-            
+
             XCTAssertNotNil(tags["OS version"], "Missing tags data (OS Version)")
             XCTAssertNotNil(tags["Device model"], "Missing tags data (Device Model)")
         }
@@ -342,23 +363,23 @@ class RavenClientTests: XCTestCase {
             XCTFail("Could not parse the tag information")
         }
     }
-    
+
     func testClientWithLogger() {
         let testMessage = "An example message"
         let loggerValue = "Logger value"
         let clientWithExtraAndTags = MockRavenClient(config: config!, extra: ["key" : "value"], tags: ["key" : "value"], logger: loggerValue)
-        
+
         clientWithExtraAndTags.captureMessage(testMessage)
-        
+
         let lastEvent = clientWithExtraAndTags.lastEvent
-        
+
         if let message = lastEvent["message"] as? String {
             XCTAssertEqual(message, testMessage, "Incorrect value for message \(message)")
         }
         else {
             XCTFail("Message was not a string")
         }
-        
+
         if let logger = lastEvent["logger"] as? String {
             XCTAssertEqual(logger, loggerValue, "Incorrect valid for the logger \(logger)")
         }

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -28,34 +28,34 @@ private var _RavenClientSharedInstance : RavenClient?
 public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDataDelegate  {
     //MARK: - Properties
     public var extra: [String: AnyObject]
-    public var tags: [String: String]
-    public var user: [String: String]?
+    public var tags: [String: AnyObject]
+    public var user: [String: AnyObject]?
     public let logger: String?
-    
+
     internal let config: RavenConfig
-    
+
     private var dateFormatter : NSDateFormatter {
         let dateFormatter = NSDateFormatter()
         dateFormatter.timeZone = NSTimeZone(name: "UTC")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         return dateFormatter
     }
-    
-    
+
+
     //MARK: - Init
-    
-    
+
+
     /**
     Get the shared RavenClient instance
     */
     public class var sharedClient: RavenClient? {
         return _RavenClientSharedInstance
     }
-    
-   
+
+
     /**
     Initialize the RavenClient
-    
+
     :param: config  RavenConfig object
     :param: extra  extra data that will be sent with logs
     :param: tags  extra tags that will be added to logs
@@ -66,15 +66,15 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         self.extra = extra
         self.tags = tags
         self.logger = logger
-        
+
         super.init()
         setDefaultTags()
     }
-    
-    
+
+
     /**
     Initialize the RavenClient
-    
+
     :param: config  RavenConfig object
     :param: extra  extra data that will be sent with logs
     :param: tags  extra tags that will be added to logs
@@ -82,46 +82,46 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     public convenience init(config: RavenConfig, extra: [String: AnyObject], tags: [String: String]) {
         self.init(config: config, extra: extra, tags: tags, logger: nil)
     }
-    
-    
+
+
     /**
     Initialize the RavenClient
-    
+
     :param: config  RavenConfig object
     :param: extra  extra data that will be sent with logs
     */
     public convenience init(config: RavenConfig, extra: [String: AnyObject]) {
         self.init(config: config, extra: extra, tags: [:], logger: nil)
     }
-    
-    
+
+
     /**
     Initialize the RavenClient
-    
+
     :param: config  RavenConfig object
     */
     public convenience init(config: RavenConfig) {
         self.init(config: config, extra: [:], tags: [:], logger: nil)
     }
 
-    
+
     /**
     Initialize a RavenClient from the DSN string
-    
+
     :param: extra  extra data that will be sent with logs
     :param: tags  extra tags that will be added to logs
     :param: logger  Name of the logger
-    
+
     :returns: The RavenClient instance
     */
     public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String], logger: String?) -> RavenClient? {
         if let config = RavenConfig(DSN: DSN) {
             let client = RavenClient(config: config, extra: extra, tags: tags, logger: logger)
-            
+
             if (_RavenClientSharedInstance == nil) {
                 _RavenClientSharedInstance = client
             }
-            
+
             return client
         }
         else {
@@ -129,142 +129,142 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
             return nil
         }
     }
-    
-    
+
+
     /**
     Initialize a RavenClient from the DSN string
-    
+
     :param: extra  extra data that will be sent with logs
     :param: tags  extra tags that will be added to logs
-    
+
     :returns: The RavenClient instance
     */
     public class func clientWithDSN(DSN: String, extra: [String: AnyObject], tags: [String: String]) -> RavenClient? {
         return RavenClient.clientWithDSN(DSN, extra: extra, tags: tags, logger: nil)
     }
-    
-    
+
+
     /**
     Initialize a RavenClient from the DSN string
-    
+
     :param: extra  extra data that will be sent with logs
-    
+
     :returns: The RavenClient instance
     */
     public class func clientWithDSN(DSN: String, extra: [String: AnyObject]) -> RavenClient? {
         return RavenClient.clientWithDSN(DSN, extra: extra, tags: [:])
     }
-    
-    
+
+
     /**
     Initialize a RavenClient from the DSN string
-    
+
     :returns: The RavenClient instance
     */
     public class func clientWithDSN(DSN: String) -> RavenClient? {
         return RavenClient.clientWithDSN(DSN, extra: [:])
     }
 
-    
+
     //MARK: - Messages
-    
-    
+
+
     /**
     Capture a message
-    
+
     :param: message  The message to be logged
     */
     public func captureMessage(message : String, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__) {
         self.captureMessage(message, level: .Info, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
-    
-    
+
+
     /**
     Capture a message
-    
+
     :param: message  The message to be logged
     :param: level  log level
     */
     public func captureMessage(message: String, level: RavenLogLevel, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__){
         self.captureMessage(message, level: level, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
-    
-    
+
+
     /**
     Capture a message
-    
+
     :param: message  The message to be logged
     :param: level  log level
     :param: additionalExtra  Additional data that will be sent with the log
     :param: additionalTags  Additional tags that will be sent with the log
     */
-    public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: String], method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__) {
+    public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: AnyObject], method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__) {
         var stacktrace : [AnyObject] = []
         var culprit : String = ""
-        
+
         if (method != nil && file != nil && line > 0) {
             let filename = (file! as NSString).lastPathComponent;
             let frame = ["filename" : filename, "function" : method!, "lineno" : line]
             stacktrace = [frame]
             culprit = "\(method!) in \(filename)"
         }
-        
+
         let data = self.prepareDictionaryForMessage(message, level:level, additionalExtra:additionalExtra, additionalTags:additionalTags, culprit:culprit, stacktrace:stacktrace, exception:[:])
-        
+
         self.sendDictionary(data)
     }
-    
-    
+
+
     //MARK: - Error
-    
-    /** 
+
+    /**
     Capture an error
-    
+
     :param: error  The error to capture
     */
     public func captureError(error : NSError, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
         RavenClient.sharedClient?.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
-    
-    
+
+
     //MARK: - ErrorType
-    
+
     /**
     Capture an error that conforms the ErrorType protocol
-    
+
     :param: error  The error to capture
     */
     public func captureError<E where E:ErrorType, E:StringLiteralConvertible>(error: E, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
         RavenClient.sharedClient?.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
-    
-    
+
+
     //MARK: - Exception
-    
-    
+
+
     /**
     Capture an exception. Automatically sends to the server
-    
+
     :param: exception  The exception to be captured.
     */
     public func captureException(exception: NSException) {
         self.captureException(exception, sendNow:true)
     }
-    
-    
+
+
     /**
     Capture an uncaught exception. Does not automatically send to the server
-    
+
     :param: exception  The exception to be captured.
     */
     public func captureUncaughtException(exception: NSException) {
         self.captureException(exception, sendNow: false)
     }
-    
-    
+
+
     /**
     Capture an exception
-    
+
     :param: exception  The exception to be captured.
     :param: additionalExtra  Additional data that will be sent with the log
     :param: additionalTags  Additional tags that will be sent with the log
@@ -273,19 +273,19 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
     public func captureException(exception:NSException, additionalExtra:[String: AnyObject], additionalTags: [String: String], sendNow:Bool) {
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason!]
-        
+
         let callStack = exception.callStackSymbols
-        
+
         var stacktrace = [[String:String]]()
-        
+
         if (!callStack.isEmpty) {
             for call in callStack {
                 stacktrace.append(["function": call])
             }
         }
-        
+
         let data = self.prepareDictionaryForMessage(message, level: .Fatal, additionalExtra: additionalExtra, additionalTags: additionalTags, culprit: nil, stacktrace: stacktrace, exception: exceptionDict)
-        
+
         if let JSON = self.encodeJSON(data) {
             if (!sendNow) {
                 // We can't send this exception to Sentry now, e.g. because the app is killed before the
@@ -297,7 +297,7 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
                 } else {
                     reports = [JSONString!]
                 }
-                
+
                 NSUserDefaults.standardUserDefaults().setObject(reports, forKey:userDefaultsKey)
                 NSUserDefaults.standardUserDefaults().synchronize()
             } else {
@@ -305,20 +305,20 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
             }
         }
     }
-    
-    
+
+
     /**
     Capture an exception
-    
+
     :param: exception  The exception to be captured.
     :param: sendNow  Control whether the exception is sent to the server now, or when the app is next opened
     */
     public func captureException(exception: NSException, method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__, sendNow:Bool = false) {
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason ?? ""]
-        
+
         var stacktrace = [[String:AnyObject]]()
-        
+
         if (method != nil && file != nil && line > 0) {
             var frame = [String: AnyObject]()
             frame = ["filename" : (file! as NSString).lastPathComponent, "function" : method!, "lineno" : line]
@@ -330,9 +330,9 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         for call in callStack {
             stacktrace.append(["function": call])
         }
-        
+
         let data = self.prepareDictionaryForMessage(message, level: .Fatal, additionalExtra: [:], additionalTags: [:], culprit: nil, stacktrace: stacktrace, exception: exceptionDict)
-        
+
         if let JSON = self.encodeJSON(data) {
             if (!sendNow) {
                 // We can't send this exception to Sentry now, e.g. because the app is killed before the
@@ -352,14 +352,14 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         }
     }
 
-    
+
     /**
     Automatically capture any uncaught exceptions
     */
     public func setupExceptionHandler() {
         UncaughtExceptionHandler.registerHandler(self)
         NSSetUncaughtExceptionHandler(exceptionHandlerPtr)
-        
+
         // Process saved crash reports
         let reports : [AnyObject]? = NSUserDefaults.standardUserDefaults().arrayForKey(userDefaultsKey)
         if (reports != nil && reports?.count > 0) {
@@ -373,20 +373,20 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         }
     }
 
-    
+
     //MARK: - NSURLConnection
     public func connection(connection: NSURLConnection, didFailWithError error: NSError) {
         let userInfo = error.userInfo as! [String: AnyObject]
         let errorKey: AnyObject? = userInfo[NSURLErrorFailingURLStringErrorKey]
         print("Connection failed! Error - \(error.localizedDescription) \(errorKey!)")
     }
-  
+
     public func connection(connection: NSURLConnection, didReceiveResponse response: NSURLResponse) {
         #if DEBUG
             println("Response from Sentry: \(response)")
         #endif
     }
-    
+
     public func connectionDidFinishLoading(connection: NSURLConnection) {
         print("JSON sent to Sentry")
     }
@@ -399,51 +399,51 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
                 tags["Build version"] = buildVersion as? String
             }
         }
-        
+
         #if os(iOS)
             if (tags["OS version"] == nil) {
                 tags["OS version"] = UIDevice.currentDevice().systemVersion
             }
-            
+
             if (tags["Device model"] == nil) {
                 tags["Device model"] = UIDevice.currentDevice().model
             }
         #endif
-        
+
     }
-    
+
     internal func sendDictionary(dict: [String: AnyObject]) {
         let JSON = self.encodeJSON(dict)
         self.sendJSON(JSON)
     }
-    
+
     internal func generateUUID() -> String {
         let uuid = NSUUID().UUIDString
         let res = uuid.stringByReplacingOccurrencesOfString("-", withString: "", options: NSStringCompareOptions.LiteralSearch, range: nil)
         return res
     }
-    
+
     private func prepareDictionaryForMessage(message: String,
         level: RavenLogLevel,
         additionalExtra: [String : AnyObject],
-        additionalTags: [String : String],
+        additionalTags: [String : AnyObject],
         culprit:String?,
         stacktrace:[AnyObject],
         exception:[String : String]) -> [String: AnyObject]
     {
-        
+
         let stacktraceDict : [String : [AnyObject]] = ["frames": stacktrace]
-        
+
         var extra = self.extra
         for entry in additionalExtra {
             extra[entry.0] = entry.1
         }
-        
+
         var tags = self.tags;
         for entry in additionalTags {
             tags[entry.0] = entry.1
         }
-        
+
         let returnDict : [String: AnyObject] = ["event_id" : self.generateUUID(),
             "project"   : self.config.projectId!,
             "timestamp" : self.dateFormatter.stringFromDate(NSDate()),
@@ -457,10 +457,10 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
             "stacktrace": stacktraceDict,
             "exception" : exception,
             "user"      : user ?? ""]
-        
+
         return returnDict
     }
-    
+
     private func encodeJSON(obj: AnyObject) -> NSData? {
         do {
             return try NSJSONSerialization.dataWithJSONObject(obj, options: [])
@@ -468,14 +468,14 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
             return nil
         }
     }
-    
+
     private func sendJSON(JSON: NSData?) {
         let header = "Sentry sentry_version=\(sentryProtocol), sentry_client=\(sentryClient), sentry_timestamp=\(NSDate.timeIntervalSinceReferenceDate()), sentry_key=\(self.config.publicKey), sentry_secret=\(self.config.secretKey)"
-        
+
         #if DEBUG
         println(header)
         #endif
-        
+
         let request = NSMutableURLRequest(URL: self.config.serverUrl)
         request.HTTPMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -483,9 +483,9 @@ public class RavenClient : NSObject, NSURLConnectionDelegate, NSURLConnectionDat
         request.setValue("\(JSON?.length)", forHTTPHeaderField: "Content-Length")
         request.HTTPBody = JSON
         request.setValue("\(header)", forHTTPHeaderField:"X-Sentry-Auth")
-        
+
         _ = NSURLConnection(request: request, delegate: self)
-        
+
         #if DEBUG
         let debug = NSString(data: JSON!, encoding: NSUTF8StringEncoding)
         println(debug)

--- a/RavenSwift.podspec
+++ b/RavenSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RavenSwift"
-  s.version      = "0.3.0"
+  s.version      = "0.3.1"
   s.summary      = "swift client for sentry"
   s.homepage     = "https://github.com/getsentry/raven-swift"
   s.license      = "mit"


### PR DESCRIPTION
In 0.2.0, the `tags` and `user` dictionaries accepted AnyObject as values. In the current version, they accept only Strings. 

In a project I'm working on, we commonly set boolean or numerical values in these dictionaries. This PR brings this functionality back. I also updated the tests suite to check for this.
