### PR TITLE
Allow empty DSN

### DIFF
--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -230,7 +230,7 @@ public class RavenClient : NSObject {
     :param: error  The error to capture
     */
     public func captureError(error : NSError, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
-        RavenClient.sharedClient?.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
+        self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 
 
@@ -242,7 +242,7 @@ public class RavenClient : NSObject {
     :param: error  The error to capture
     */
     public func captureError<E where E:ErrorType, E:StringLiteralConvertible>(error: E, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
-        RavenClient.sharedClient?.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
+        self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 
 


### PR DESCRIPTION
According to the documentation ([Writing a Client](https://sentry.readthedocs.org/en/7.1.0/developer/client/index.html)) a DSN should not be required. This PR changes the RavenClient class to accept an empty DSN. In case of an empty DSN, RavenClient will operate without a config instance (and not attempt to send data remotely)

PR also fixes a bug in RavenClient where captureError() tried to invoke captureMessage() on the shared client, instead of 'self'.
