### PR TITLE
Change generic captureError<E> to conform to CustomStringConvertible. And Update to Swift 2.2

### DIFF
--- a/Raven-Swift.xcodeproj/project.pbxproj
+++ b/Raven-Swift.xcodeproj/project.pbxproj
@@ -643,7 +643,7 @@
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Raven/Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -670,7 +670,7 @@
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Raven/Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/Raven-Swift.xcodeproj/xcshareddata/xcschemes/Raven-tvOS.xcscheme
+++ b/Raven-Swift.xcodeproj/xcshareddata/xcschemes/Raven-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63A8B07D1C335347003A99FF"
-               BuildableName = "Raven-tvOS.framework"
+               BuildableName = "Raven.framework"
                BlueprintName = "Raven-tvOS"
                ReferencedContainer = "container:Raven-Swift.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "63A8B07D1C335347003A99FF"
-            BuildableName = "Raven-tvOS.framework"
+            BuildableName = "Raven.framework"
             BlueprintName = "Raven-tvOS"
             ReferencedContainer = "container:Raven-Swift.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "63A8B07D1C335347003A99FF"
-            BuildableName = "Raven-tvOS.framework"
+            BuildableName = "Raven.framework"
             BlueprintName = "Raven-tvOS"
             ReferencedContainer = "container:Raven-Swift.xcodeproj">
          </BuildableReference>

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -181,7 +181,7 @@ public class RavenClient : NSObject {
 
     :param: message  The message to be logged
     */
-    public func captureMessage(message : String, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureMessage(message : String, method: String? = #function , file: String? = #file, line: Int = #line) {
         self.captureMessage(message, level: .Info, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
 
@@ -192,7 +192,7 @@ public class RavenClient : NSObject {
     :param: message  The message to be logged
     :param: level  log level
     */
-    public func captureMessage(message: String, level: RavenLogLevel, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__){
+    public func captureMessage(message: String, level: RavenLogLevel, method: String? = #function , file: String? = #file, line: Int = #line){
         self.captureMessage(message, level: level, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
 
@@ -205,7 +205,7 @@ public class RavenClient : NSObject {
     :param: additionalExtra  Additional data that will be sent with the log
     :param: additionalTags  Additional tags that will be sent with the log
     */
-    public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: AnyObject], method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__) {
+    public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: AnyObject], method:String? = #function, file:String? = #file, line:Int = #line) {
         var stacktrace : [AnyObject] = []
         var culprit : String = ""
 
@@ -229,7 +229,7 @@ public class RavenClient : NSObject {
 
     :param: error  The error to capture
     */
-    public func captureError(error : NSError, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureError(error : NSError, method: String? = #function, file: String? = #file, line: Int = #line) {
         self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 
@@ -241,7 +241,7 @@ public class RavenClient : NSObject {
 
     :param: error  The error to capture
     */
-    public func captureError<E where E:ErrorType, E:CustomStringConvertible>(error: E, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureError<E where E:ErrorType, E:CustomStringConvertible>(error: E, method: String? = #function, file: String? = #file, line: Int = #line) {
         self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 
@@ -320,7 +320,7 @@ public class RavenClient : NSObject {
     :param: exception  The exception to be captured.
     :param: sendNow  Control whether the exception is sent to the server now, or when the app is next opened
     */
-    public func captureException(exception: NSException, method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__, sendNow:Bool = false) {
+    public func captureException(exception: NSException, method:String? = #function, file:String? = #file, line:Int = #line, sendNow:Bool = false) {
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason ?? ""]
 

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -241,7 +241,7 @@ public class RavenClient : NSObject {
 
     :param: error  The error to capture
     */
-    public func captureError<E where E:ErrorType, E:StringLiteralConvertible>(error: E, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureError<E where E:ErrorType, E:CustomStringConvertible>(error: E, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
         self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 


### PR DESCRIPTION
`StringLiteralConvertible` is for string literals. `CustomStringConvertible` is to provide a `description`.
